### PR TITLE
Remove trailing slashes from sonar.url

### DIFF
--- a/sync_target/sonar.py
+++ b/sync_target/sonar.py
@@ -10,7 +10,7 @@ class SonarGroups(object):
         self.groups_search_path = "api/user_groups/search"
         self.group_create_path = "api/user_groups/create"
         self.group_delete_path = "api/user_groups/delete"
-        self.url = cfg['sonar']['url']
+        self.url = cfg['sonar']['url'].rstrip('/')
         self.token = cfg['sonar']['token']
         self.keep_local_groups = cfg['sonar']['keep_local_groups']
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
In case we have two consecutive slashes in the full_url when querying for the groups in Sonar, the system will respond with a page showing the loading spinner. This will obviously not be acceptable for the JSON parser. To avoid this situation, we should handle a common configuration "error" and remove trailing slashes from the sonar.url.